### PR TITLE
Allows modpack makers to add packmode aliases and descriptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,4 @@ run/
 !gradle-wrapper.jar
 
 gradlew*
+/a.bat

--- a/.gitignore
+++ b/.gitignore
@@ -118,4 +118,3 @@ run/
 !gradle-wrapper.jar
 
 gradlew*
-/a.bat

--- a/src/main/java/me/illgilp/packmodemenu/gui/ConfigScreen.java
+++ b/src/main/java/me/illgilp/packmodemenu/gui/ConfigScreen.java
@@ -48,11 +48,10 @@ public final class ConfigScreen extends GuiScreen {
         }
         switchBtn = new GuiButtonExt(0, width / 2 - 100, height / 6, getButtonText());
         buttonList.add(switchBtn);
-        saveBtn = new GuiButtonExt(1, this.width / 2 - 155, this.height / 6 + 160 - 6, 150, 20, I18n.format("packmodemenu.options.save"));
+        saveBtn = new GuiButtonExt(1, this.width / 2 - 155, this.height - 50, 150, 20, I18n.format("packmodemenu.options.save"));
         saveBtn.enabled = !mode.equals(defaultMode);
         this.buttonList.add(saveBtn);
-        this.buttonList.add(new GuiButtonExt(2, this.width / 2 + 5, this.height / 6 + 160 - 6, 150, 20, I18n.format("packmodemenu.options.cancel")));
-
+        this.buttonList.add(new GuiButtonExt(2, this.width / 2 + 5, this.height - 50, 150, 20, I18n.format("packmodemenu.options.cancel")));
 
         super.initGui();
         firstInit = false;
@@ -82,7 +81,7 @@ public final class ConfigScreen extends GuiScreen {
                 textMultiline.append(ChatFormatting.RED).append(line).append("\n");
             }
         }
-        this.drawMultilineString(textMultiline.toString(), this.width / 2, this.height / 6 + 50 - 6, 0xffffff);
+        this.drawMultilineString(textMultiline.toString(), this.width / 2, this.height / 6 + 40 - 6, 0xffffff);
         super.drawScreen(mouseX, mouseY, partialTicks);
     }
 

--- a/src/main/java/me/illgilp/packmodemenu/gui/ConfigScreen.java
+++ b/src/main/java/me/illgilp/packmodemenu/gui/ConfigScreen.java
@@ -1,5 +1,6 @@
 package me.illgilp.packmodemenu.gui;
 
+import com.mojang.realmsclient.gui.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiScreen;
@@ -9,7 +10,6 @@ import net.minecraftforge.common.config.Property;
 import net.minecraftforge.fml.client.config.GuiButtonExt;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 
@@ -36,7 +36,7 @@ public final class ConfigScreen extends GuiScreen {
         configuration = new Configuration(new File("config/packmode.cfg"));
         configuration.load();
         packMode = configuration.get("general", "packMode", "normal");
-        acceptedModes = configuration.get("general", "acceptedModes", new String[] {"normal", "expert"});
+        acceptedModes = configuration.get("general", "acceptedModes", new String[]{"normal", "expert"});
 
     }
 
@@ -48,10 +48,10 @@ public final class ConfigScreen extends GuiScreen {
         }
         switchBtn = new GuiButtonExt(0, width / 2 - 100, height / 6, getButtonText());
         buttonList.add(switchBtn);
-        saveBtn = new GuiButtonExt(1, this.width / 2 - 155, this.height / 6 + 120 - 6, 150, 20, I18n.format("packmodemenu.options.save"));
+        saveBtn = new GuiButtonExt(1, this.width / 2 - 155, this.height / 6 + 160 - 6, 150, 20, I18n.format("packmodemenu.options.save"));
         saveBtn.enabled = !mode.equals(defaultMode);
         this.buttonList.add(saveBtn);
-        this.buttonList.add(new GuiButtonExt(2, this.width / 2 + 5, this.height / 6 + 120 - 6, 150, 20, I18n.format("packmodemenu.options.cancel")));
+        this.buttonList.add(new GuiButtonExt(2, this.width / 2 + 5, this.height / 6 + 160 - 6, 150, 20, I18n.format("packmodemenu.options.cancel")));
 
 
         super.initGui();
@@ -59,23 +59,35 @@ public final class ConfigScreen extends GuiScreen {
     }
 
     private String getButtonText() {
-        return I18n.format("packmodemenu.options.pack_mode") + ": " + (!mode.equals(defaultMode) ? "§a" : "") + mode.toUpperCase() + (!mode.equals(defaultMode) ? "" : " (" + I18n.format("packmodemenu.options.current") + ")");
+        String translatedModeName;
+        if (I18n.hasKey("packmodemenu.packmode.name." + mode)) {
+            translatedModeName = I18n.format("packmodemenu.packmode.name." + mode);
+        } else {
+            translatedModeName = mode.toUpperCase();
+        }
+        return I18n.format("packmodemenu.options.pack_mode") + ": " + (!mode.equals(defaultMode) ? "§a" : "") + translatedModeName + (!mode.equals(defaultMode) ? "" : " (" + I18n.format("packmodemenu.options.current") + ")");
     }
 
     @Override
     public void drawScreen(int mouseX, int mouseY, float partialTicks) {
         drawDefaultBackground();
-        this.drawCenteredString(this.fontRenderer, I18n.format("packmodemenu.options.pack_mode"), this.width / 2, 15, 16777215);
-
-        if (!mode.equals(defaultMode)) {
-            this.drawCenteredString(this.fontRenderer, I18n.format("packmodemenu.options.warning.restart.line1"), this.width / 2, this.height / 6 + 75 - 6, 0xFF5555);
-            this.drawCenteredString(this.fontRenderer, I18n.format("packmodemenu.options.warning.restart.line2"), this.width / 2, this.height / 6 + 75 - 6 + 10, 0xFF5555);
+        this.drawCenteredString(this.fontRenderer, I18n.format("packmodemenu.options.pack_mode"), this.width / 2, 15, 0xffffff);
+        StringBuilder textMultiline = new StringBuilder();
+        if (I18n.hasKey("packmodemenu.packmode.desc." + mode)) {
+            textMultiline.append(I18n.format("packmodemenu.packmode.desc." + mode).replace("\\n", "\n")).append("\n\n");
         }
+        if (!mode.equals(defaultMode)) {
+            String[] warningText = I18n.format("packmodemenu.options.warning.restart").split("\\\\n");
+            for (String line : warningText) {
+                textMultiline.append(ChatFormatting.RED).append(line).append("\n");
+            }
+        }
+        this.drawMultilineString(textMultiline.toString(), this.width / 2, this.height / 6 + 50 - 6, 0xffffff);
         super.drawScreen(mouseX, mouseY, partialTicks);
     }
 
     @Override
-    protected void actionPerformed(GuiButton button) throws IOException {
+    protected void actionPerformed(GuiButton button) {
         if (button.id == switchBtn.id) {
             mode = acceptedModes.getStringList()[(new ArrayList<>(Arrays.asList(acceptedModes.getStringList())).lastIndexOf(mode) + 1) % acceptedModes.getStringList().length];
             switchBtn.displayString = getButtonText();
@@ -86,6 +98,15 @@ public final class ConfigScreen extends GuiScreen {
             Minecraft.getMinecraft().displayGuiScreen(this.lastScreen);
         } else {
             Minecraft.getMinecraft().displayGuiScreen(this.lastScreen);
+        }
+    }
+
+    public void drawMultilineString(String textMultiline, int x, int y, int color) {
+        String[] texts = textMultiline.split("\\n");
+        int offset = 0;
+        for (String text : texts) {
+            this.drawCenteredString(this.fontRenderer, text, x, y + offset, color);
+            offset += 10;
         }
     }
 }

--- a/src/main/resources/assets/packmodemenu/lang/de_de.lang
+++ b/src/main/resources/assets/packmodemenu/lang/de_de.lang
@@ -2,5 +2,4 @@ packmodemenu.options.pack_mode=Pack-Modus
 packmodemenu.options.save=Speichern
 packmodemenu.options.cancel=Abbrechen
 packmodemenu.options.current=aktuell
-packmodemenu.options.warning.restart.line1=Nach dem Speichern muss das Spiel neugestartet
-packmodemenu.options.warning.restart.line2=werden, damit die Änderungen übernommen werden.
+packmodemenu.options.warning.restart=Nach dem Speichern muss das Spiel neugestartet\nwerden, damit die Änderungen übernommen werden.

--- a/src/main/resources/assets/packmodemenu/lang/en_us.lang
+++ b/src/main/resources/assets/packmodemenu/lang/en_us.lang
@@ -2,5 +2,4 @@ packmodemenu.options.pack_mode=Pack-Mode
 packmodemenu.options.save=Save
 packmodemenu.options.cancel=Cancel
 packmodemenu.options.current=current
-packmodemenu.options.warning.restart.line1=After saving you have to restart the game
-packmodemenu.options.warning.restart.line2=for the changes to take effect.
+packmodemenu.options.warning.restart=After saving you have to restart the game\nfor the changes to take effect.

--- a/src/main/resources/assets/packmodemenu/lang/zh_cn.lang
+++ b/src/main/resources/assets/packmodemenu/lang/zh_cn.lang
@@ -1,5 +1,5 @@
 packmodemenu.options.pack_mode=整合包模式
 packmodemenu.options.save=保存
 packmodemenu.options.cancel=取消
-packmodemenu.options.current=当前整合包模式
+packmodemenu.options.current=当前模式
 packmodemenu.options.warning.restart=你必须在保存后重新启动游戏\n才能应用更改。

--- a/src/main/resources/assets/packmodemenu/lang/zh_cn.lang
+++ b/src/main/resources/assets/packmodemenu/lang/zh_cn.lang
@@ -2,5 +2,4 @@ packmodemenu.options.pack_mode=整合包模式
 packmodemenu.options.save=保存
 packmodemenu.options.cancel=取消
 packmodemenu.options.current=当前整合包模式
-packmodemenu.options.warning.restart.line1=你必须在保存后重新启动游戏
-packmodemenu.options.warning.restart.line2=才能应用更改。
+packmodemenu.options.warning.restart=你必须在保存后重新启动游戏\n才能应用更改。


### PR DESCRIPTION
Allows modpack makers to add packmode aliases and descriptions via translation keys. They can do that easily with resource loader (a resource pack or CaftTweaker also works)
Aliases can be added with the key "packmodemenu.packmode.name.[packmode name]", if the key does not exist this will be defaulted to the uppercase packmode id.
descriptions can be added with the key "packmodemenu.packmode.desc.[packmode name]", can be multilined and colored.
Also repositioned the gui elements so that more descriptions can be displayed.
If this is merged you can add the above instructions to the mod description, thanks! 